### PR TITLE
Added functionality to edit submission ratings

### DIFF
--- a/src/main/kotlin/com/example/atlasbackend/classes/SubmissionRating.kt
+++ b/src/main/kotlin/com/example/atlasbackend/classes/SubmissionRating.kt
@@ -1,0 +1,3 @@
+package com.example.atlasbackend.classes
+
+data class SubmissionRating(var submission_id: Int, var grade: Int?, var teacher_id: Int?, var comment: String?)

--- a/src/main/kotlin/com/example/atlasbackend/controller/SubmissionController.kt
+++ b/src/main/kotlin/com/example/atlasbackend/controller/SubmissionController.kt
@@ -2,6 +2,7 @@ package com.example.atlasbackend.controller
 
 import com.example.atlasbackend.classes.AtlasUser
 import com.example.atlasbackend.classes.Submission
+import com.example.atlasbackend.classes.SubmissionRating
 import com.example.atlasbackend.service.SubmissionService
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
@@ -67,6 +68,17 @@ class SubmissionController(val submissionService: SubmissionService) {
     @PutMapping("/submissions")
     fun editSubmission(@Parameter(hidden = true ) @AuthenticationPrincipal user: AtlasUser, @RequestBody body: Submission): Submission {
         return submissionService.editSubmission(user, body)
+    }
+
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "OK - Edits Submission "),
+            ApiResponse(responseCode = "404", description = "SubmissionNotFoundException", content = [Content(schema = Schema(hidden = true))]),
+            ApiResponse(responseCode = "403", description = "NoPermissionToEditExerciseException", content = [Content(schema = Schema(hidden = true))])
+        ])
+    @PutMapping("/submissions/rating")
+    fun editSubmissionRating(@Parameter(hidden = true ) @AuthenticationPrincipal user: AtlasUser, @RequestBody body: SubmissionRating): Submission {
+        return submissionService.editSubmissionRating(user, body)
     }
 
     @ApiResponses(

--- a/src/main/kotlin/com/example/atlasbackend/service/SubmissionService.kt
+++ b/src/main/kotlin/com/example/atlasbackend/service/SubmissionService.kt
@@ -2,6 +2,7 @@ package com.example.atlasbackend.service
 
 import com.example.atlasbackend.classes.AtlasUser
 import com.example.atlasbackend.classes.Submission
+import com.example.atlasbackend.classes.SubmissionRating
 import com.example.atlasbackend.exception.*
 import com.example.atlasbackend.repository.ExerciseRepository
 import com.example.atlasbackend.repository.ModuleRepository
@@ -66,6 +67,7 @@ class SubmissionService(val subRep: SubmissionRepository, val exRep: ExerciseRep
     }
 
     fun editSubmission(user: AtlasUser, s: Submission): Submission {
+        val oldSub = subRep.findById(s.submission_id).get()
 
         // Error Catching
         if (!subRep.existsById(s.submission_id)) throw SubmissionNotFoundException
@@ -76,7 +78,25 @@ class SubmissionService(val subRep: SubmissionRepository, val exRep: ExerciseRep
             throw NoPermissionToEditSubmissionException
 
         // Functionality
-        val updatedSubmission = Submission(s.submission_id, s.exercise_id, s.user_id, s.file, s.upload_time, s.grade, s.teacher_id, s.comment)
+        var updatedSubmission = Submission(s.submission_id, s.exercise_id, s.user_id, s.file, s.upload_time, s.grade, s.teacher_id, s.comment)
+        if(user.user_id == s.user_id && !user.roles.any { r -> r.role_id == 1}) {     // User can't edit his own grade, unless admin
+            updatedSubmission = Submission(s.submission_id, s.exercise_id, s.user_id, s.file, s.upload_time, oldSub.grade, oldSub.teacher_id, oldSub.comment)
+        }
+        subRep.save(updatedSubmission)
+        return updatedSubmission
+    }
+
+    fun editSubmissionRating(user: AtlasUser, sr: SubmissionRating): Submission {
+        val s = subRep.findById(sr.submission_id).get()
+
+        // Error Catching
+        if (!subRep.existsById(sr.submission_id)) throw SubmissionNotFoundException
+        if (!user.roles.any { r -> r.role_id == 1} &&   // Check for admin
+            modRep.getModuleRoleByUser(user.user_id, exRep.getModuleByExercise(s.exercise_id).module_id).let { mru -> mru == null || mru.role_id > 3 })   // Check for tutor/teacher
+            throw NoPermissionToEditSubmissionException
+
+        // Functionality
+        val updatedSubmission = Submission(sr.submission_id, s.exercise_id, s.user_id, s.file, s.upload_time, sr.grade, sr.teacher_id, sr.comment)
         subRep.save(updatedSubmission)
         return updatedSubmission
     }


### PR DESCRIPTION
### Changelog

[NEW] `PUT /submissions/ratings` editiert nur die Bewertung einer Abgabe, nimmt submission_id, grade, teacher_id & comment entgegen
[CHANGE] `PUT /submissions` kann nun keine Bewertungen mehr editieren, nur noch als Admin. Wirft keinen Error wenns passiert, sondern bleibt einfach gleich.
[NEW] `SubmissionRating` Klasse, damit ich das als Body nutzen konnte
