### PR TITLE
Module optional "public" machen

### DIFF
--- a/src/main/kotlin/com/example/atlasbackend/classes/AtlasModule.kt
+++ b/src/main/kotlin/com/example/atlasbackend/classes/AtlasModule.kt
@@ -1,7 +1,8 @@
 package com.example.atlasbackend.classes
 
 import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Table
 
 @Table("module")
-data class AtlasModule(@Id var module_id: Int, var name: String, var description: String)
+data class AtlasModule(@Id var module_id: Int, var name: String, var description: String, @field:Column("public") var modulePublic: Boolean?)

--- a/src/main/kotlin/com/example/atlasbackend/service/ModuleService.kt
+++ b/src/main/kotlin/com/example/atlasbackend/service/ModuleService.kt
@@ -47,6 +47,7 @@ class ModuleService(val modRep: ModuleRepository, val roleRep: RoleRepository, v
         if (!user.roles.any { r -> r.role_id <= 2}) throw NoPermissionToEditModuleException   // Check for admin/teacher
 
         // Functionality
+        if(module.modulePublic == null) module.modulePublic = false // Accept NULL value, but convert to false
         val savedModule = modRep.save(module)
         modRep.addUser(user.user_id,module.module_id,2) // when creating a module u should be added as teacher
         return savedModule


### PR DESCRIPTION
### Changelog

Modules can now be set to "public"
[CHANGE] Class `AtlasModule` has new field `modulePublic` of type `Boolean?` (Nullable)

This doesn't impact how the Frontend currently works, since `modulePublic` doesn't have to be set.
If it's explicitely set to true, the module will be public, otherwise it's private by default.
